### PR TITLE
Fixed response documentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -533,11 +533,13 @@ function convertToHTML(swaggerJSON){
                         hasResponseSchema = true;
                     }
                     else{
-                        responseSchemaHTML += "   <tr>";
-                        responseSchemaHTML += "       <td class='td-alignment-small'>&nbsp;</td>";
-                        responseSchemaHTML += "       <td class='td-alignment-std'>" + renderSchemaItems(responseSchema, swaggerJSON.definitions) + "</td>";
-                        responseSchemaHTML += "   </tr>";
-                        hasResponseSchema = true;
+                        if (typeof responseSchema["$ref"] !== "undefined" || responseSchema.type == "array") {
+                            responseSchemaHTML += "   <tr>";
+                            responseSchemaHTML += "       <td class='td-alignment-small'>&nbsp;</td>";
+                            responseSchemaHTML += "       <td class='td-alignment-std'>" + renderSchemaItems(responseSchema, swaggerJSON.definitions) + "</td>";
+                            responseSchemaHTML += "   </tr>";
+                            hasResponseSchema = true;
+                        }
                     }
                 }
                 responseSchemaHTML += "       </table>";      
@@ -736,9 +738,9 @@ function renderSchemaItems(schemaItems, swaggerDefinitions){
 
     }
     else{
-
-        html += "Other schema item:" + schemaItems;
-
+        if(typeof schemaItems.type !== "undefined"){
+            html += "Items type: " + schemaItems.type;
+        }
     }
 
     return html;


### PR DESCRIPTION
Fixed a bad case of response documentation.
Generated HTML/PDF contained "Other schema item: [object Object]" for
all built-in types (array, string, bool, etc...)
See issue #20.